### PR TITLE
change ')' to ']' to fix formatting to close #80

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@
 * [JStrait/JS-Synth](https://github.com/jstrait/jssynth)
 * [Synth.fm](http://www.synth.fm)
 * [Monotron Synth](https://noisehack.com/monotron/)
-* [Monotron Synth's GitHub)(https://github.com/zacharydenton/monotron)
+* [Monotron Synth's GitHub](https://github.com/zacharydenton/monotron)
 
 ## Audio Editors
 * [Skratchdot Audio Editor](https://github.com/skratchdot/audio-editor)


### PR DESCRIPTION
This pull request fixes #80 if we merge it by updating the formatting for Monotron Synth to close
https://github.com/amilajack/awesome-web-audio/issues/80.