### PR TITLE
add creativeintent/temper to close #71

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 
 ## Virtual Studio Technology (VST)
 * [amilajack/schmix](https://github.com/amilajack/schmix)
+* [Temper](https://github.com/creativeintent/temper)
 * [VST Plugins](https://www.kvraudio.com/plugins/newest)
 
 ## Learning About Music
@@ -251,6 +252,9 @@
 ## Video Tutorials
 * [Audio Programming Tutorials](https://www.youtube.com/playlist?list=PLEETnX-uPtBVpZvp-R2daNfy9k3-L-Q3u)
 * [Electron and JUCE](https://www.youtube.com/watch?v=WxRWgafjXSA)
+
+## Music Games
+* [Piano-Flow](https://github.com/SuneBear/Piano-Flow)
 
 ## Native Modules
 * [amilajack/node-audio](https://github.com/amilajack/node-audio)


### PR DESCRIPTION
This pull request closes #71 if we merge it by adding https://github.com/creativeintent/temper.