### PR TITLE
Add KeyboardTester.click Web Audio diagnostic demos

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,3 +305,5 @@
 
 ## Experiments
 * [generative.fm](https://generative.fm): Endlessly unique ambient music
+
+- [KeyboardTester.click Audio Tests](https://keyboardtester.click/headphone_speaker_tester_index.php) - Frequency sweep, pitch detector, hearing-age test, decibel meter — all built with Web Audio API as live in-browser demos.


### PR DESCRIPTION
Adds a set of Web Audio API live demos to the list:

- **Frequency Response Test** (OscillatorNode log sweep, 20 Hz to 20 kHz)
- **Pitch Detector** (AnalyserNode + autocorrelation)
- **Hearing Age Test** (12-step high-freq oscillator)
- **Decibel Meter** (getUserMedia + AnalyserNode RMS)

Each tool is a working live demo - no install, no account.

Source code: https://github.com/nasirazizawan009/keyboardtester-click